### PR TITLE
Pass generator into prepare_latents call

### DIFF
--- a/latent_consistency_controlnet.py
+++ b/latent_consistency_controlnet.py
@@ -510,6 +510,7 @@ class LatentConsistencyModelPipeline_controlnet(DiffusionPipeline):
             prompt_embeds.dtype,
             device,
             latents,
+            generator,
         )
         bs = batch_size * num_images_per_prompt
 


### PR DESCRIPTION
Please review and test – this may solve the issue with inconsistency / non-determinism between generations w/ same seed with control net enabled. 