### PR TITLE
Fixes issue where controlNet is non-deterministic 

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -14,6 +14,7 @@ build:
     - "diffusers==0.22.3"
     - "Pillow==10.1.0"
     - "transformers==4.34.1"
+   # - "pytorch-lightning==1.9.1"
     - "xformers==0.0.22"
     - "opencv-python-headless==4.8.1.78"
   run:

--- a/cog.yaml
+++ b/cog.yaml
@@ -14,7 +14,6 @@ build:
     - "diffusers==0.22.3"
     - "Pillow==10.1.0"
     - "transformers==4.34.1"
-   # - "pytorch-lightning==1.9.1"
     - "xformers==0.0.22"
     - "opencv-python-headless==4.8.1.78"
   run:

--- a/latent_consistency_controlnet.py
+++ b/latent_consistency_controlnet.py
@@ -510,6 +510,7 @@ class LatentConsistencyModelPipeline_controlnet(DiffusionPipeline):
             prompt_embeds.dtype,
             device,
             latents,
+            generator,
         )
         bs = batch_size * num_images_per_prompt
 

--- a/predict.py
+++ b/predict.py
@@ -277,7 +277,6 @@ class Predictor(BasePredictor):
         print(f"Using seed: {seed}")
 
         os.environ['PYTHONHASHSEED'] = str(seed)
-        np.random.seed(seed)
         torch.manual_seed(seed)
         torch.cuda.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)

--- a/predict.py
+++ b/predict.py
@@ -276,6 +276,14 @@ class Predictor(BasePredictor):
 
         print(f"Using seed: {seed}")
 
+        os.environ['PYTHONHASHSEED'] = str(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
         prompt = prompt.strip().splitlines()
         if len(prompt) == 1:
             print("Found 1 prompt:")


### PR DESCRIPTION
Tested this on Replicate and seems to be working. 

This could potential be done clearer using the 'seed everything' dependency, but this approach introduces no new dependencies. 

By seeding all the usual suspects, we're able to get deterministic outputs. 

Recommend testing before pulling into main, but looks good on this end. 